### PR TITLE
Reference to nuget package EntityCloner.Microsoft.EntityFrameworkCore is obsolete and will be deleted in next major version

### DIFF
--- a/DataAccessClient.EntityFrameworkCore.Relational/DataAccessClient.EntityFrameworkCore.Relational.csproj
+++ b/DataAccessClient.EntityFrameworkCore.Relational/DataAccessClient.EntityFrameworkCore.Relational.csproj
@@ -14,7 +14,7 @@
     <PackageReleaseNotes></PackageReleaseNotes>
     <Copyright>Henk Kin</Copyright>
     <PackageTags>EntityFrameworkCore, EF, Relational (SqlServer and PostgreSQL), DependencyInjection, Multiple DbContext support, DataAccess, Repository, UnitOfWork, SoftDelete, Translation, Localization, RowVersioning, Multitenancy, Filtering, Paging, Sorting, Includes</PackageTags>
-    <Version>10.1.1</Version>
+    <Version>10.1.2</Version>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>

--- a/DataAccessClient.EntityFrameworkCore.Relational/RelationalRepository.cs
+++ b/DataAccessClient.EntityFrameworkCore.Relational/RelationalRepository.cs
@@ -94,6 +94,7 @@ namespace DataAccessClient.EntityFrameworkCore.Relational
             return DbSet.Update(entity).Entity;
         }
 
+        [Obsolete("Use EntityCloner.Microsoft.EntityFrameworkCore nuget package directly.")]
         public async Task<TEntity> CloneAsync(params object[] id)
         {
             ThrowIfInvalidPrimaryKey(id, _primaryKeyProperties);
@@ -102,6 +103,7 @@ namespace DataAccessClient.EntityFrameworkCore.Relational
             return clonedEntity;
         }
 
+        [Obsolete("Use EntityCloner.Microsoft.EntityFrameworkCore nuget package directly.")]
         public async Task<TEntity> CloneAsync(Func<IClonableQueryable<TEntity>, IClonableQueryable<TEntity>> includeQuery, params object[] id)
         {
             ThrowIfInvalidPrimaryKey(id, _primaryKeyProperties);

--- a/DataAccessClient.EntityFrameworkCore.SqlServer/DataAccessClient.EntityFrameworkCore.SqlServer.csproj
+++ b/DataAccessClient.EntityFrameworkCore.SqlServer/DataAccessClient.EntityFrameworkCore.SqlServer.csproj
@@ -14,7 +14,7 @@
     <PackageReleaseNotes></PackageReleaseNotes>
     <Copyright>Henk Kin</Copyright>
     <PackageTags>EntityFrameworkCore, EF, SqlServer, DependencyInjection, Multiple DbContext support, DataAccess, Repository, UnitOfWork, SoftDelete, Translation, Localization, RowVersioning, Multitenancy, Filtering, Paging, Sorting, Includes</PackageTags>
-    <Version>10.1.1</Version>
+    <Version>10.1.2</Version>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>

--- a/DataAccessClient.EntityFrameworkCore.SqlServer/SqlServerRepository.cs
+++ b/DataAccessClient.EntityFrameworkCore.SqlServer/SqlServerRepository.cs
@@ -94,6 +94,7 @@ namespace DataAccessClient.EntityFrameworkCore.SqlServer
             return DbSet.Update(entity).Entity;
         }
 
+        [Obsolete("Use EntityCloner.Microsoft.EntityFrameworkCore nuget package directly.")]
         public async Task<TEntity> CloneAsync(params object[] id)
         {
             ThrowIfInvalidPrimaryKey(id, _primaryKeyProperties);
@@ -102,6 +103,7 @@ namespace DataAccessClient.EntityFrameworkCore.SqlServer
             return clonedEntity;
         }
 
+        [Obsolete("Use EntityCloner.Microsoft.EntityFrameworkCore nuget package directly.")]
         public async Task<TEntity> CloneAsync(Func<IClonableQueryable<TEntity>, IClonableQueryable<TEntity>> includeQuery, params object[] id)
         {
             ThrowIfInvalidPrimaryKey(id, _primaryKeyProperties);

--- a/DataAccessClient/DataAccessClient.csproj
+++ b/DataAccessClient/DataAccessClient.csproj
@@ -14,7 +14,7 @@
     <PackageTags>DataAccess Repository, UnitOfWork, Multitenancy, SoftDelete, RowVersioning, Filtering, Paging, Translation, Localization, Sorting, Includes</PackageTags>
     <Description>Provides interfaces for Data Access with IRepository&lt;T&gt; and IUnitOfWork. Also provides haviorial interfaces for entities like IIdentifiable, ICreatable, IModifiable, ISoftDeletable, ITranslatable, ILocalizable, ITenantScopable and IRowVersioned. Last but not least provides some types for Exceptions and searching capabilities like Filtering,Paging, Sorting and Includes.</Description>
     <Copyright>Henk Kin</Copyright>
-    <Version>10.1.1</Version>
+    <Version>10.1.2</Version>
 	<PublishRepositoryUrl>true</PublishRepositoryUrl>
 	<EmbedUntrackedSources>true</EmbedUntrackedSources>
 	<IncludeSymbols>true</IncludeSymbols>

--- a/DataAccessClient/IRepository.cs
+++ b/DataAccessClient/IRepository.cs
@@ -26,8 +26,10 @@ namespace DataAccessClient
         
         TEntity Update(TEntity entity);
 
+        [Obsolete("Use EntityCloner.Microsoft.EntityFrameworkCore nuget package directly.")]
         Task<TEntity> CloneAsync(params object[] id);
 
+        [Obsolete("Use EntityCloner.Microsoft.EntityFrameworkCore nuget package directly.")]
         Task<TEntity> CloneAsync(Func<IClonableQueryable<TEntity>, IClonableQueryable<TEntity>> includeQuery, params object[] id);
     }
 }


### PR DESCRIPTION
Reference to nuget package EntityCloner.Microsoft.EntityFrameworkCore is obsolete and will be deleted in next major version.

IRepository.CloneAsync methods will be removed in next major version.