### PR TITLE
Make ExecutionContext available on RelationalDbContext en SqlServerDbContext to get the individual entitybehaviors in your own code.

### DIFF
--- a/DataAccessClient.EntityFrameworkCore.Relational/DataAccessClient.EntityFrameworkCore.Relational.csproj
+++ b/DataAccessClient.EntityFrameworkCore.Relational/DataAccessClient.EntityFrameworkCore.Relational.csproj
@@ -14,7 +14,7 @@
     <PackageReleaseNotes></PackageReleaseNotes>
     <Copyright>Henk Kin</Copyright>
     <PackageTags>EntityFrameworkCore, EF, Relational (SqlServer and PostgreSQL), DependencyInjection, Multiple DbContext support, DataAccess, Repository, UnitOfWork, SoftDelete, Translation, Localization, RowVersioning, Multitenancy, Filtering, Paging, Sorting, Includes</PackageTags>
-    <Version>10.1.2</Version>
+    <Version>10.1.3</Version>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>

--- a/DataAccessClient.EntityFrameworkCore.Relational/RelationalDbContext.cs
+++ b/DataAccessClient.EntityFrameworkCore.Relational/RelationalDbContext.cs
@@ -33,7 +33,7 @@ namespace DataAccessClient.EntityFrameworkCore.Relational
                 BindingFlags.Instance | BindingFlags.NonPublic);
         }
 
-        internal RelationalDbContextExecutionContext ExecutionContext { get; private set; }
+        public RelationalDbContextExecutionContext ExecutionContext { get; private set; }
 
         private readonly Action _dbContextResetStateMethod;
         private readonly Func<CancellationToken, Task> _dbContextResetStateAsyncMethod;

--- a/DataAccessClient.EntityFrameworkCore.Relational/RelationalDbContextExecutionContext.cs
+++ b/DataAccessClient.EntityFrameworkCore.Relational/RelationalDbContextExecutionContext.cs
@@ -2,11 +2,11 @@
 
 namespace DataAccessClient.EntityFrameworkCore.Relational
 {
-    internal class RelationalDbContextExecutionContext
+    public class RelationalDbContextExecutionContext
     {
         private readonly Dictionary<string, dynamic> _context;
 
-        public RelationalDbContextExecutionContext(Dictionary<string, dynamic> context)
+        internal RelationalDbContextExecutionContext(Dictionary<string, dynamic> context)
         {
             _context = context;
         }
@@ -16,9 +16,27 @@ namespace DataAccessClient.EntityFrameworkCore.Relational
             return (T)_context[typeof(T).Name];
         }
 
+        public T TryGet<T>()
+        {
+            if (_context.TryGetValue(typeof(T).Name, out var value))
+            {
+                return (T)value;
+            }
+            return default;
+        }
+
         public T Get<T>(string name)
         {
             return (T)_context[name];
+        }
+
+        public T TryGet<T>(string name)
+        {
+            if (_context.TryGetValue(name, out var value))
+            {
+                return (T)value;
+            }
+            return default;
         }
     }
 }

--- a/DataAccessClient.EntityFrameworkCore.Relational/ServiceCollectionExtensions.cs
+++ b/DataAccessClient.EntityFrameworkCore.Relational/ServiceCollectionExtensions.cs
@@ -100,30 +100,30 @@ namespace DataAccessClient.EntityFrameworkCore.Relational
         private static Type GetUserIdentifierType(this IServiceCollection services)
         {
             var registration =
-                services.SingleOrDefault(s =>
+                services.FirstOrDefault(s =>
                     s.ServiceType.IsGenericType &&
                     s.ServiceType.GetGenericTypeDefinition() == typeof(IUserIdentifierProvider<>) &&
-                    s.Lifetime == ServiceLifetime.Scoped);
+                    (s.Lifetime == ServiceLifetime.Scoped || s.Lifetime == ServiceLifetime.Singleton));
             return registration?.ServiceType.GenericTypeArguments[0];
         }
 
         private static Type GetTenantIdentifierType(this IServiceCollection services)
         {
             var registration =
-                services.SingleOrDefault(s =>
+                services.FirstOrDefault(s =>
                     s.ServiceType.IsGenericType &&
                     s.ServiceType.GetGenericTypeDefinition() == typeof(ITenantIdentifierProvider<>) &&
-                    s.Lifetime == ServiceLifetime.Scoped);
+                    (s.Lifetime == ServiceLifetime.Scoped || s.Lifetime == ServiceLifetime.Singleton));
             return registration?.ServiceType.GenericTypeArguments[0];
         }
 
         private static Type GetLocaleIdentifierType(this IServiceCollection services)
         {
             var registration =
-                services.SingleOrDefault(s =>
+                services.FirstOrDefault(s =>
                     s.ServiceType.IsGenericType &&
                     s.ServiceType.GetGenericTypeDefinition() == typeof(ILocaleIdentifierProvider<>) &&
-                    s.Lifetime == ServiceLifetime.Scoped);
+                    (s.Lifetime == ServiceLifetime.Scoped || s.Lifetime == ServiceLifetime.Singleton));
             return registration?.ServiceType.GenericTypeArguments[0];
         }
     }

--- a/DataAccessClient.EntityFrameworkCore.SqlServer/DataAccessClient.EntityFrameworkCore.SqlServer.csproj
+++ b/DataAccessClient.EntityFrameworkCore.SqlServer/DataAccessClient.EntityFrameworkCore.SqlServer.csproj
@@ -14,7 +14,7 @@
     <PackageReleaseNotes></PackageReleaseNotes>
     <Copyright>Henk Kin</Copyright>
     <PackageTags>EntityFrameworkCore, EF, SqlServer, DependencyInjection, Multiple DbContext support, DataAccess, Repository, UnitOfWork, SoftDelete, Translation, Localization, RowVersioning, Multitenancy, Filtering, Paging, Sorting, Includes</PackageTags>
-    <Version>10.1.2</Version>
+    <Version>10.1.3</Version>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>

--- a/DataAccessClient.EntityFrameworkCore.SqlServer/ServiceCollectionExtensions.cs
+++ b/DataAccessClient.EntityFrameworkCore.SqlServer/ServiceCollectionExtensions.cs
@@ -94,30 +94,30 @@ namespace DataAccessClient.EntityFrameworkCore.SqlServer
         private static Type GetUserIdentifierType(this IServiceCollection services)
         {
             var registration =
-                services.SingleOrDefault(s =>
+                services.FirstOrDefault(s =>
                     s.ServiceType.IsGenericType &&
                     s.ServiceType.GetGenericTypeDefinition() == typeof(IUserIdentifierProvider<>) &&
-                    s.Lifetime == ServiceLifetime.Scoped);
+                    (s.Lifetime == ServiceLifetime.Scoped || s.Lifetime == ServiceLifetime.Singleton));
             return registration?.ServiceType.GenericTypeArguments[0];
         }
 
         private static Type GetTenantIdentifierType(this IServiceCollection services)
         {
             var registration =
-                services.SingleOrDefault(s =>
+                services.FirstOrDefault(s =>
                     s.ServiceType.IsGenericType &&
                     s.ServiceType.GetGenericTypeDefinition() == typeof(ITenantIdentifierProvider<>) &&
-                    s.Lifetime == ServiceLifetime.Scoped);
+                    (s.Lifetime == ServiceLifetime.Scoped || s.Lifetime == ServiceLifetime.Singleton));
             return registration?.ServiceType.GenericTypeArguments[0];
         }
 
         private static Type GetLocaleIdentifierType(this IServiceCollection services)
         {
             var registration =
-                services.SingleOrDefault(s =>
+                services.FirstOrDefault(s =>
                     s.ServiceType.IsGenericType &&
                     s.ServiceType.GetGenericTypeDefinition() == typeof(ILocaleIdentifierProvider<>) &&
-                    s.Lifetime == ServiceLifetime.Scoped);
+                    (s.Lifetime == ServiceLifetime.Scoped || s.Lifetime == ServiceLifetime.Singleton));
             return registration?.ServiceType.GenericTypeArguments[0];
         }
     }

--- a/DataAccessClient.EntityFrameworkCore.SqlServer/SqlServerDbContext.cs
+++ b/DataAccessClient.EntityFrameworkCore.SqlServer/SqlServerDbContext.cs
@@ -31,7 +31,7 @@ namespace DataAccessClient.EntityFrameworkCore.SqlServer
                 BindingFlags.Instance | BindingFlags.NonPublic);
         }
 
-        internal SqlServerDbContextExecutionContext ExecutionContext { get; private set; }
+        public SqlServerDbContextExecutionContext ExecutionContext { get; private set; }
 
         private readonly Action _dbContextResetStateMethod;
         private readonly Func<CancellationToken, Task> _dbContextResetStateAsyncMethod;

--- a/DataAccessClient.EntityFrameworkCore.SqlServer/SqlServerDbContextExecutionContext.cs
+++ b/DataAccessClient.EntityFrameworkCore.SqlServer/SqlServerDbContextExecutionContext.cs
@@ -2,11 +2,11 @@
 
 namespace DataAccessClient.EntityFrameworkCore.SqlServer
 {
-    internal class SqlServerDbContextExecutionContext
+    public class SqlServerDbContextExecutionContext
     {
         private readonly Dictionary<string, dynamic> _context;
 
-        public SqlServerDbContextExecutionContext(Dictionary<string, dynamic> context)
+        internal SqlServerDbContextExecutionContext(Dictionary<string, dynamic> context)
         {
             _context = context;
         }
@@ -16,9 +16,26 @@ namespace DataAccessClient.EntityFrameworkCore.SqlServer
             return (T)_context[typeof(T).Name];
         }
 
+        public T TryGet<T>()
+        {
+            if (_context.TryGetValue(typeof(T).Name, out var value))
+            {
+                return (T)value;
+            }
+            return default;
+        }
         public T Get<T>(string name)
         {
             return (T)_context[name];
+        }
+
+        public T TryGet<T>(string name)
+        {
+            if (_context.TryGetValue(name, out var value))
+            {
+                return (T)value;
+            }
+            return default;
         }
     }
 }

--- a/DataAccessClient/DataAccessClient.csproj
+++ b/DataAccessClient/DataAccessClient.csproj
@@ -14,7 +14,7 @@
     <PackageTags>DataAccess Repository, UnitOfWork, Multitenancy, SoftDelete, RowVersioning, Filtering, Paging, Translation, Localization, Sorting, Includes</PackageTags>
     <Description>Provides interfaces for Data Access with IRepository&lt;T&gt; and IUnitOfWork. Also provides haviorial interfaces for entities like IIdentifiable, ICreatable, IModifiable, ISoftDeletable, ITranslatable, ILocalizable, ITenantScopable and IRowVersioned. Last but not least provides some types for Exceptions and searching capabilities like Filtering,Paging, Sorting and Includes.</Description>
     <Copyright>Henk Kin</Copyright>
-    <Version>10.1.2</Version>
+    <Version>10.1.3</Version>
 	<PublishRepositoryUrl>true</PublishRepositoryUrl>
 	<EmbedUntrackedSources>true</EmbedUntrackedSources>
 	<IncludeSymbols>true</IncludeSymbols>

--- a/DataAccessClientExample-10/DataLayer/ExampleLocaleIdentifierProvider.cs
+++ b/DataAccessClientExample-10/DataLayer/ExampleLocaleIdentifierProvider.cs
@@ -10,7 +10,7 @@ namespace DataAccessClientExample.DataLayer
             return LocaleId;
         }
 
-        public void ChangeTentantIdentifier(string localeIdentifier)
+        public void ChangeLocaleIdentifier(string localeIdentifier)
         {
             LocaleId = localeIdentifier;
         }

--- a/DataAccessClientExample-6/DataLayer/ExampleLocaleIdentifierProvider.cs
+++ b/DataAccessClientExample-6/DataLayer/ExampleLocaleIdentifierProvider.cs
@@ -10,7 +10,7 @@ namespace DataAccessClientExample.DataLayer
             return LocaleId;
         }
 
-        public void ChangeTentantIdentifier(string localeIdentifier)
+        public void ChangeLocaleIdentifier(string localeIdentifier)
         {
             LocaleId = localeIdentifier;
         }

--- a/DataAccessClientExample-7/DataLayer/ExampleLocaleIdentifierProvider.cs
+++ b/DataAccessClientExample-7/DataLayer/ExampleLocaleIdentifierProvider.cs
@@ -10,7 +10,7 @@ namespace DataAccessClientExample.DataLayer
             return LocaleId;
         }
 
-        public void ChangeTentantIdentifier(string localeIdentifier)
+        public void ChangeLocaleIdentifier(string localeIdentifier)
         {
             LocaleId = localeIdentifier;
         }

--- a/DataAccessClientExample-8/DataLayer/ExampleLocaleIdentifierProvider.cs
+++ b/DataAccessClientExample-8/DataLayer/ExampleLocaleIdentifierProvider.cs
@@ -10,7 +10,7 @@ namespace DataAccessClientExample.DataLayer
             return LocaleId;
         }
 
-        public void ChangeTentantIdentifier(string localeIdentifier)
+        public void ChangeLocaleIdentifier(string localeIdentifier)
         {
             LocaleId = localeIdentifier;
         }

--- a/DataAccessClientExample-9/DataLayer/ExampleLocaleIdentifierProvider.cs
+++ b/DataAccessClientExample-9/DataLayer/ExampleLocaleIdentifierProvider.cs
@@ -10,7 +10,7 @@ namespace DataAccessClientExample.DataLayer
             return LocaleId;
         }
 
-        public void ChangeTentantIdentifier(string localeIdentifier)
+        public void ChangeLocaleIdentifier(string localeIdentifier)
         {
             LocaleId = localeIdentifier;
         }

--- a/DataAccessClientExample.PostgreSql-10/DataLayer/ExampleLocaleIdentifierProvider.cs
+++ b/DataAccessClientExample.PostgreSql-10/DataLayer/ExampleLocaleIdentifierProvider.cs
@@ -10,7 +10,7 @@ namespace DataAccessClientExample.DataLayer
             return LocaleId;
         }
 
-        public void ChangeTentantIdentifier(string localeIdentifier)
+        public void ChangeLocaleIdentifier(string localeIdentifier)
         {
             LocaleId = localeIdentifier;
         }

--- a/DataAccessClientExample.PostgreSql/DataLayer/ExampleLocaleIdentifierProvider.cs
+++ b/DataAccessClientExample.PostgreSql/DataLayer/ExampleLocaleIdentifierProvider.cs
@@ -10,7 +10,7 @@ namespace DataAccessClientExample.DataLayer
             return LocaleId;
         }
 
-        public void ChangeTentantIdentifier(string localeIdentifier)
+        public void ChangeLocaleIdentifier(string localeIdentifier)
         {
             LocaleId = localeIdentifier;
         }

--- a/DataAccessClientExample.SqlServer-10/DataLayer/ExampleLocaleIdentifierProvider.cs
+++ b/DataAccessClientExample.SqlServer-10/DataLayer/ExampleLocaleIdentifierProvider.cs
@@ -10,7 +10,7 @@ namespace DataAccessClientExample.DataLayer
             return LocaleId;
         }
 
-        public void ChangeTentantIdentifier(string localeIdentifier)
+        public void ChangeLocaleIdentifier(string localeIdentifier)
         {
             LocaleId = localeIdentifier;
         }

--- a/DataAccessClientExample.SqlServer/DataLayer/ExampleLocaleIdentifierProvider.cs
+++ b/DataAccessClientExample.SqlServer/DataLayer/ExampleLocaleIdentifierProvider.cs
@@ -10,7 +10,7 @@ namespace DataAccessClientExample.DataLayer
             return LocaleId;
         }
 
-        public void ChangeTentantIdentifier(string localeIdentifier)
+        public void ChangeLocaleIdentifier(string localeIdentifier)
         {
             LocaleId = localeIdentifier;
         }

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ When using this package, there are two required implementation you have to provi
  - ITenantIdentifierProvider<TTenantIdentifierType>
  - ILocaleIdentifierProvider<TLocaleIdentifierType>
 
-These three providers have to be registered with Scoped Lifetime in DependencyInjection. They are only required when it is needed for the EntityBehaviors you have implemented.
+These three providers have to be registered with Scoped or Singleton Lifetime in DependencyInjection. They are only required when it is needed for the EntityBehaviors you have implemented.
 
 #### IUserIdentifierProvider<TUserIdentifierType>
 
@@ -567,9 +567,9 @@ public class Startup
         var entityTypes = new [] { typeof(Entity1), typeof(Entity2) }; // can also done by using reflection
         ...
         
-        services.AddScoped<IUserIdentifierProvider<int>, ExampleUserIdentifierProvider>();
-        services.AddScoped<ITenantIdentifierProvider<int>, ExampleTenantIdentifierProvider>();
-        services.AddScoped<ILocaleIdentifierProvider<string>, ExampleLocaleIdentifierProvider>();
+        services.AddSingleton<IUserIdentifierProvider<int>, ExampleUserIdentifierProvider>();
+        services.AddSingleton<ITenantIdentifierProvider<int>, ExampleTenantIdentifierProvider>();
+        services.AddSingleton<ILocaleIdentifierProvider<string>, ExampleLocaleIdentifierProvider>();
         
         // register as DataAccessClient
         services.AddDataAccessClient<ExampleDbContext>(conf => conf


### PR DESCRIPTION
Make ExecutionContext available on RelationalDbContext en SqlServerDbContext to get the individual entitybehaviors in your own code.